### PR TITLE
enable swap & memory cgroups, clean up isolinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN mkdir $LB ;\
 RUN cp /usr/share/doc/live-build/examples/hooks/stripped.chroot $LB/config/hooks/
 ADD kernelclean.chroot $LB/config/hooks/
 ADD docker.chroot $LB/config/hooks/
+ADD bootloader.binary $LB/config/hooks/
 ADD reqs.list.chroot $LB/config/package-lists/
+ADD isolinux/ $LB/config/includes.binary/isolinux/
 WORKDIR /root/lb
 CMD ["lb", "build"]

--- a/bootloader.binary
+++ b/bootloader.binary
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+# remove unneeded isolinux files
+rm -f binary/isolinux/advanced.cfg
+rm -f binary/isolinux/hdt.c32
+rm -f binary/isolinux/vesamenu.c32
+rm -f binary/isolinux/live.cfg
+rm -f binary/isolinux/menu.cfg
+rm -f binary/isolinux/install.cfg
+rm -f binary/isolinux/splash.png
+rm -f binary/isolinux/stdmenu.cfg
+

--- a/isolinux/isolinux.cfg
+++ b/isolinux/isolinux.cfg
@@ -1,0 +1,9 @@
+default debian2docker
+label debian2docker
+        kernel /live/vmlinuz
+        initrd /live/initrd.img
+        append loglevel=3 username=docker console=ttyS0 console=tty0 boot=live config nomodeset norestore cgroup_enable=memory swapaccount=1
+
+implicit 0
+prompt 1
+timeout 2


### PR DESCRIPTION
This enables swap accounting and the memory cgroups.

It also removes unneeded isolinux files created by live-build.
