### PR TITLE
automount: fix another typo

### DIFF
--- a/includes.chroot/lib/live/config/0161-automount
+++ b/includes.chroot/lib/live/config/0161-automount
@@ -18,7 +18,7 @@ if [ ! -n "$BOOT2DOCKER_DATA" -a ! -n "$BOOT2DOCKER_DATA" ]; then
         HEADERB2D=`dd if=$UNPARTITIONED_HD bs=1 count=${#MAGICB2D} 2>/dev/null`
         HEADERD2D=`dd if=$UNPARTITIONED_HD bs=1 count=${#MAGICB2D} 2>/dev/null`
 
-        if [ "$HEADERD2D" = "$MAGICD2D"]; then
+        if [ "$HEADERD2D" = "$MAGICD2D" ]; then
             # Create the partition, format it and then mount it
             echo "NEW debian2docker managed disk image ($UNPARTITIONED_HD): formatting it for use"
             echo "NEW debian2docker managed disk image ($UNPARTITIONED_HD): formatting it for use" > /home/docker/log.log


### PR DESCRIPTION
- '[' '' = 'debian2docker, please format-me]'
  /lib/live/config/0161-automount: line 21: [: missing `]'
