### PR TITLE
grab the tar file data from boot2docker-cli

### DIFF
--- a/includes.chroot/lib/live/config/0161-automount
+++ b/includes.chroot/lib/live/config/0161-automount
@@ -1,82 +1,72 @@
 #!/bin/sh
 
-LABELB2D=boot2docker-data
+LABEL=boot2docker-data
 LABELD2D=debian2docker-data
-MAGICB2D="boot2docker, please format-me"
-MAGICD2D="debian2docker, please format-me"
+MAGIC="boot2docker, please format-me"
 
-# Look for partitions labeled boot2docker-data and debian2docker-data
-BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABELB2D || true`
-DEBIAN2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABELD2D || true`
+# If there is a partition with `boot2docker-data` as its label, use it and be
+# very happy. Thus, you can come along if you feel like a room without a roof.
+BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABEL` || true
+if [ ! -n "$BOOT2DOCKER_DATA" ]; then
+    BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABELD2D` || true
+fi
 
-if [ ! -n "$BOOT2DOCKER_DATA" -a ! -n "$BOOT2DOCKER_DATA" ]; then
+if [ ! -n "$BOOT2DOCKER_DATA" ]; then
     # Is the disk unpartitioned?, test for the 'boot2docker format-me' string
     UNPARTITIONED_HD=`fdisk -l 2>&1 | grep "doesn't contain a valid partition table" | head -n 1 | sed 's/Disk \(.*\) doesn.*/\1/'`
 
     if [ -n "$UNPARTITIONED_HD" ]; then
         # Test for our magic string (it means that the disk was made by ./boot2docker init)
-        HEADERB2D=`dd if=$UNPARTITIONED_HD bs=1 count=${#MAGICB2D} 2>/dev/null`
-        HEADERD2D=`dd if=$UNPARTITIONED_HD bs=1 count=${#MAGICD2D} 2>/dev/null`
+        HEADER=`dd if=$UNPARTITIONED_HD bs=1 count=${#MAGIC} 2>/dev/null`
 
-        if [ "$HEADERD2D" = "$MAGICD2D" ]; then
-            # Create the partition, format it and then mount it
-            echo "NEW debian2docker managed disk image ($UNPARTITIONED_HD): formatting it for use"
-            echo "NEW debian2docker managed disk image ($UNPARTITIONED_HD): formatting it for use" > /home/docker/log.log
-
-            # make one big partition
-            (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
-            DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
-            mkfs.ext4 -L $LABELD2D $DOCKER_DATA
-
-        elif [ "$HEADERB2D" = "$MAGICB2D" ]; then
+        if [ "$HEADER" = "$MAGIC" ]; then
+            # save the preload userdata.tar file
+            dd if=$UNPARTITIONED_HD of=/userdata.tar bs=1 count=4096 2>/dev/null
             # Create the partition, format it and then mount it
             echo "NEW boot2docker managed disk image ($UNPARTITIONED_HD): formatting it for use"
             echo "NEW boot2docker managed disk image ($UNPARTITIONED_HD): formatting it for use" > /home/docker/log.log
 
-            # make one big partition
+            # Add a swap partition (so Docker doesn't complain about it missing)
+            (echo n; echo p; echo 2; echo ; echo +1000M ; echo w) | fdisk $UNPARTITIONED_HD
+            (echo t; echo 82) | fdisk $UNPARTITIONED_HD
+            mkswap "${UNPARTITIONED_HD}2"
+            # Add the data partition
             (echo n; echo p; echo 1; echo ; echo ; echo w) | fdisk $UNPARTITIONED_HD
-            DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
-            mkfs.ext4 -L $LABELB2D $DOCKER_DATA
+            BOOT2DOCKER_DATA=`echo "${UNPARTITIONED_HD}1"`
+            mkfs.ext4 -L $LABEL $BOOT2DOCKER_DATA
         fi
     else
         # Pick the first ext4 as a fallback
         # TODO: mount all Linux partitions and look for a /var/lib/docker...
-        DOCKER_DATA=`blkid | grep 'TYPE="ext4"' | head -n 1 | sed 's/:.*//'`
+        BOOT2DOCKER_DATA=`blkid | grep 'TYPE="ext4"' | head -n 1 | sed 's/:.*//'`
     fi
 fi
 
-if [ -n "$DEBIAN2DOCKER_DATA" ]; then
-    DOCKER_DATA=$DEBIAN2DOCKER_DATA
-elif [ -n "$BOOT2DOCKER_DATA" ]; then
-    DOCKER_DATA=$BOOT2DOCKER_DATA
-fi
-
-
-if [ -n "$DOCKER_DATA" ]; then
-    PARTNAME=`echo "$DOCKER_DATA" | sed 's/.*\///'`
+if [ -n "$BOOT2DOCKER_DATA" ]; then
+    PARTNAME=`echo "$BOOT2DOCKER_DATA" | sed 's/.*\///'`
     mkdir -p /mnt/$PARTNAME
-    if ! mount $DOCKER_DATA /mnt/$PARTNAME 2>/dev/null; then
+    if ! mount $BOOT2DOCKER_DATA /mnt/$PARTNAME 2>/dev/null; then
         # for some reason, mount doesn't like to modprobe btrfs
-        DOCKER_FSTYPE=`blkid -o export $DOCKER_DATA | grep TYPE= | cut -d= -f2`
-        modprobe $DOCKER_FSTYPE || true
-        mount $DOCKER_DATA /mnt/$PARTNAME
+        BOOT2DOCKER_FSTYPE=`blkid -o export $BOOT2DOCKER_DATA | grep TYPE= | cut -d= -f2`
+        modprobe $BOOT2DOCKER_FSTYPE || true
+        mount $BOOT2DOCKER_DATA /mnt/$PARTNAME
     fi
 
     # Just in case, the links will fail if not
-    rm -rf /var/lib/docker /var/lib/boot2docker /var/lib/debian2docker
+    rm -rf /var/lib/docker /var/lib/boot2docker
     if [ -d /mnt/$PARTNAME/vm ]; then
         # The old behavior - use the entire disk for boot2docker data
         ln -s /mnt/$PARTNAME /var/lib/docker
 
         # Give us a link to the new cusomisation location
-        ln -s /var/lib/docker/vm /var/lib/debian2docker
+        ln -s /var/lib/docker/vm /var/lib/boot2docker
 
         # Make sure /tmp is on the disk too too
-        if [ -d /var/lib/debian2docker/tmp ]; then
-            rm -rf /var/lib/debian2docker/tmp
+        if [ -d /var/lib/boot2docker/tmp ]; then
+            rm -rf /var/lib/boot2docker/tmp
         fi
-        mv /tmp /var/lib/debian2docker/tmp
-        ln -s /var/lib/debian2docker/tmp /tmp
+        mv /tmp /var/lib/boot2docker/tmp
+        ln -s /var/lib/boot2docker/tmp /tmp
     else
         # Detected a disk with a normal linux install (/var/lib/docker + more))
         mkdir -p /var/lib
@@ -84,8 +74,8 @@ if [ -n "$DOCKER_DATA" ]; then
         mkdir -p /mnt/$PARTNAME/var/lib/docker
         ln -s /mnt/$PARTNAME/var/lib/docker /var/lib/docker
 
-        mkdir -p /mnt/$PARTNAME/var/lib/debian2docker
-        ln -s /mnt/$PARTNAME/var/lib/debian2docker /var/lib/debian2docker
+        mkdir -p /mnt/$PARTNAME/var/lib/boot2docker
+        ln -s /mnt/$PARTNAME/var/lib/boot2docker /var/lib/boot2docker
 
         # Make sure /tmp is on the disk too too
         if [ -d /mnt/$PARTNAME/tmp ]; then
@@ -94,5 +84,15 @@ if [ -n "$DOCKER_DATA" ]; then
         mv /tmp /mnt/$PARTNAME/tmp
         ln -s /mnt/$PARTNAME/tmp /tmp
     fi
+    if [ -e "/userdata.tar" ]; then
+        mv /userdata.tar /var/lib/boot2docker/
+    fi
+fi
+# /etc dirs are initialised from /usr/local, to allow the user/admin to customise
+mkdir -p /var/lib/boot2docker/etc/
 
+#preload data from boot2docker-cli
+if [ -e "/var/lib/boot2docker/userdata.tar" ]; then
+    tar xf /var/lib/boot2docker/userdata.tar -C /home/docker/
+    chown -R docker:staff /home/docker
 fi


### PR DESCRIPTION
One small modification from the b2d automount script.

I've removed references to debian2docker - if we're going to use this iso to replace the existing one, we'll need to use the boot2docker brand.

(if you have a partition with the debian2docker label it will mount it)
