### PR TITLE
setting divide=10 in the boot params

### DIFF
--- a/includes.binary/boot/isolinux/isolinux.cfg
+++ b/includes.binary/boot/isolinux/isolinux.cfg
@@ -2,7 +2,7 @@ default debian2docker
 label debian2docker
         kernel /live/vmlinuz
         initrd /live/initrd.img
-        append loglevel=3 username=docker console=ttyS0 console=tty0 boot=live config noprompt noeject nomodeset norestore cgroup_enable=memory swapaccount=1 live-getty
+        append loglevel=3 username=docker console=ttyS0 console=tty0 boot=live config noprompt noeject nomodeset norestore cgroup_enable=memory swapaccount=1 live-getty divider=10
 
 implicit 0
 prompt 1


### PR DESCRIPTION
I have no evidence that this solved the problem, but I've just run with it for the last hour, and have not had the freeze/stutter, whereas the few minutes testing beforehand I had it at least once a minute.

So I _think_ this might be worth it.

Might Close #37
