### PR TITLE
fetch the Docker tarball, not the naked binary

### DIFF
--- a/hooks/docker.chroot
+++ b/hooks/docker.chroot
@@ -4,7 +4,12 @@ set -e
 
 if [ ! -f /usr/bin/docker ]
 then
-wget https://get.docker.io/builds/Linux/x86_64/docker-latest -O /usr/bin/docker
+wget https://get.docker.io/builds/Linux/x86_64/docker-latest.tgz -O /tmp/docker.tgz
+mkdir /tmp/docker
+tar -xpf /tmp/docker.tgz -C /tmp/docker/
+rm /tmp/docker.tgz
+mv /tmp/docker/usr/local/bin/docker /usr/bin/docker
+rm -rf /tmp/docker
 fi
 
 chmod +x /usr/bin/docker


### PR DESCRIPTION
This saves bandwidth.
