### PR TITLE
fix build after the latest debian jessie changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-RUN apt-get update && apt-get -y install busybox-static adduser bzip2 xz-utils nano insserv module-init-tools sudo debootstrap cpio syslinux xorriso
+RUN apt-get update && apt-get -y install busybox-static adduser bzip2 xz-utils nano insserv kmod sudo debootstrap cpio isolinux syslinux xorriso
 ADD hooks /root/hooks
 ADD buildboot /root/buildboot/
 ADD includes.binary /root/includes.binary/

--- a/buildboot/d2d_build.sh
+++ b/buildboot/d2d_build.sh
@@ -37,12 +37,13 @@ echo "---> preparing the rootfs"
 echo "---> building the iso"
 mkdir -p /tmp/iso/boot/isolinux
 mkdir -p /tmp/iso/live/
-cp /usr/lib/syslinux/isolinux.bin /tmp/iso/boot/isolinux/
+cp /usr/lib/ISOLINUX/isolinux.bin /tmp/iso/boot/isolinux/
+cp /usr/lib/syslinux/modules/bios/ldlinux.c32 /tmp/iso/boot/isolinux/
 cp /root/vmlinuz /tmp/iso/live/
 cp /root/ramdisk-final.gz /tmp/iso/live/initrd.img
 cp -Rfp $INCLUDESBINARYDIR/* /tmp/iso/
 xorriso -as mkisofs \
 	-l -J -R -V debian2docker -no-emul-boot -boot-load-size 4 -boot-info-table \
 	-b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
-	-isohybrid-mbr /usr/lib/syslinux/isohdpfx.bin \
+	-isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin \
 	-o /debian2docker.iso /tmp/iso \

--- a/hooks/inittab-serial.chroot
+++ b/hooks/inittab-serial.chroot
@@ -1,3 +1,0 @@
-# adjust ttyS* lines in inittab to use /bin/exec-fail-sleep so that if a
-# serial cable isn't connected, we don't get respawning too fast errors
-sed -ri 's!^#(.*:)(/sbin/getty.*ttyS[0-9].*)!\1/bin/exec-fail-sleep 30 \2!' /etc/inittab


### PR DESCRIPTION
This PR packages the work done during the investigation which has lead to https://github.com/boot2docker/boot2docker/pull/543.

ISOLINUX and SYSLINUX have both been updated on Debian jessie and files have moved around a bit.

This PR also changes the package `module-init-tools` to `kmod`.

As of right now, debian2docker is using systemd by default because that's what Debian is using.
